### PR TITLE
Optimize for CPU

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -66,9 +66,9 @@ impl Component for Animation {
         Ok(())
     }
 
-    async fn update(&mut self, _context: &mut SceneContext) -> KludgineResult<()> {
-        self.manager.update().await;
-        self.frame_manager.update().await;
+    async fn update(&mut self, context: &mut SceneContext) -> KludgineResult<()> {
+        self.manager.update(context).await;
+        self.frame_manager.update(context).await;
         Ok(())
     }
 

--- a/examples/isometric.rs
+++ b/examples/isometric.rs
@@ -41,7 +41,7 @@ impl Component for Isometric {
 
 impl Isometric {
     async fn load_assets(&mut self) -> KludgineResult<()> {
-        let texture = Texture::load("kludgine/examples/assets/isometric_tile.png")?;
+        let texture = Texture::load("examples/assets/isometric_tile.png")?;
         let sprite = Sprite::single_frame(texture).await;
 
         let mut map = PersistentTileMap::persistent_with_size(

--- a/examples/orthotiles.rs
+++ b/examples/orthotiles.rs
@@ -21,7 +21,11 @@ impl WindowCreator<OrthoTiles> for OrthoTiles {
 
 static MAP_SIZE: u32 = 100;
 
-impl Window for OrthoTiles {}
+impl Window for OrthoTiles {
+    fn target_fps(&self) -> Option<u16> {
+        Some(60)
+    }
+}
 
 impl StandaloneComponent for OrthoTiles {}
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -159,7 +159,7 @@ impl EventProcessor for Runtime {
                 .unwrap_or_default();
         }
 
-        *control_flow = winit::event_loop::ControlFlow::Poll;
+        *control_flow = winit::event_loop::ControlFlow::Wait;
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3,7 +3,7 @@ use super::{
     window::{RuntimeWindow, Window, WindowBuilder},
     KludgineResult,
 };
-use crossbeam::channel::{bounded, unbounded, Receiver, Sender, TryRecvError};
+use crossbeam::channel::{unbounded, Receiver, Sender, TryRecvError};
 use futures::future::Future;
 use platforms::target::{OS, TARGET_OS};
 use std::time::Duration;
@@ -12,7 +12,7 @@ use tokio::runtime::Runtime as TokioRuntime;
 pub(crate) enum RuntimeRequest {
     OpenWindow {
         builder: WindowBuilder,
-        window_sender: Sender<winit::window::Window>,
+        window_sender: tokio::sync::mpsc::Sender<winit::window::Window>,
     },
     Quit,
 }
@@ -192,14 +192,14 @@ impl Runtime {
 
     fn internal_open_window(
         &self,
-        window_sender: Sender<winit::window::Window>,
+        mut window_sender: tokio::sync::mpsc::Sender<winit::window::Window>,
         builder: WindowBuilder,
         event_loop: &winit::event_loop::EventLoopWindowTarget<()>,
     ) {
         let builder: winit::window::WindowBuilder = builder.into();
         let winit_window = builder.build(&event_loop).unwrap();
         window_sender
-            .send(winit_window)
+            .try_send(winit_window)
             .expect("Couldn't send winit window");
     }
 
@@ -245,9 +245,9 @@ impl Runtime {
         }
         let window = Runtime::block_on(window);
         let initial_window = initial_window.build(&event_loop).unwrap();
-        let (window_sender, window_receiver) = bounded(1);
-        window_sender.send(initial_window).unwrap();
-        RuntimeWindow::open(window_receiver, window);
+        let (mut window_sender, window_receiver) = tokio::sync::mpsc::channel(1);
+        window_sender.try_send(initial_window).unwrap();
+        Runtime::block_on(RuntimeWindow::open(window_receiver, window));
         event_loop.run(move |event, event_loop, control_flow| {
             let mut event_handler_guard = GLOBAL_EVENT_HANDLER
                 .lock()
@@ -264,22 +264,20 @@ impl Runtime {
     pub fn spawn<Fut: Future<Output = T> + Send + 'static, T: Send + 'static>(
         future: Fut,
     ) -> tokio::task::JoinHandle<T> {
-        let pool = GLOBAL_THREAD_POOL.lock().expect("Error getting runtime");
-        pool.as_ref().unwrap().spawn(future)
+        Self::handle().spawn(future)
     }
 
     pub fn block_on<'a, Fut: Future<Output = R> + Send + 'a, R: Send + Sync + 'a>(
         future: Fut,
     ) -> R {
-        let mut pool = GLOBAL_THREAD_POOL.lock().expect("Error getting runtime");
-        pool.as_mut().unwrap().block_on(future)
+        Self::handle().block_on(future)
     }
 
     pub async fn open_window<T>(builder: WindowBuilder, window: T)
     where
         T: Window + Sized,
     {
-        let (window_sender, window_receiver) = bounded(1);
+        let (window_sender, window_receiver) = tokio::sync::mpsc::channel(1);
         RuntimeRequest::OpenWindow {
             builder,
             window_sender,
@@ -288,10 +286,10 @@ impl Runtime {
         .await
         .unwrap_or_default();
 
-        RuntimeWindow::open(window_receiver, window);
+        RuntimeWindow::open(window_receiver, window).await;
     }
 
-    pub async fn handle() -> tokio::runtime::Handle {
+    pub fn handle() -> tokio::runtime::Handle {
         let pool = GLOBAL_THREAD_POOL.lock().expect("Error getting runtime");
         pool.as_ref().unwrap().handle().clone()
     }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -321,7 +321,7 @@ impl Scene {
         }
     }
 
-    pub(crate) async fn start_frame(&mut self) {
+    pub(crate) async fn start_frame(&mut self) -> Moment {
         let mut scene = self.data.write().await;
         let last_start = scene.now;
         scene.now = Some(Moment::now());
@@ -330,6 +330,7 @@ impl Scene {
             None => None,
         };
         scene.elements.clear();
+        scene.now.unwrap()
     }
 
     pub async fn size(&self) -> Size<Pixels> {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -321,7 +321,7 @@ impl Scene {
         }
     }
 
-    pub(crate) async fn start_frame(&mut self) -> Moment {
+    pub(crate) async fn start_frame(&mut self) {
         let mut scene = self.data.write().await;
         let last_start = scene.now;
         scene.now = Some(Moment::now());
@@ -330,7 +330,6 @@ impl Scene {
             None => None,
         };
         scene.elements.clear();
-        scene.now.unwrap()
     }
 
     pub async fn size(&self) -> Size<Pixels> {

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -154,10 +154,10 @@ impl Sprite {
                     if json["frames"].len() == 1 {
                         Ok(0)
                     } else {
-                    Err(KludgineError::SpriteParseError(
-                        "invalid aseprite json: frame was not numeric.".to_owned(),
-                    ))
-                }
+                        Err(KludgineError::SpriteParseError(
+                            "invalid aseprite json: frame was not numeric.".to_owned(),
+                        ))
+                    }
                 })?;
 
             let duration = match frame["duration"].as_u64() {
@@ -306,6 +306,21 @@ impl Sprite {
         Ok(sprite
             .with_current_frame(|frame| frame.source.clone())
             .await?)
+    }
+
+    pub async fn remaining_frame_duration(&self) -> KludgineResult<Option<Duration>> {
+        let sprite = self.handle.read().await;
+
+        let duration = match sprite.with_current_frame(|frame| frame.duration).await? {
+            Some(frame_duration) => Some(
+                frame_duration
+                    .checked_sub(sprite.elapsed_since_frame_change)
+                    .unwrap_or_default(),
+            ),
+            None => None,
+        };
+
+        Ok(duration)
     }
 
     pub async fn animations(&self) -> SpriteAnimations {

--- a/src/text/wrap/measured.rs
+++ b/src/text/wrap/measured.rs
@@ -99,7 +99,6 @@ impl MeasuredText {
 
         measured.measure_text(text, scene).await?;
 
-        //println!("{:#?}", measured.groups);
         Ok(measured)
     }
 

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -1,15 +1,17 @@
 use chrono::{DateTime, Utc};
 use std::time::{Duration, Instant};
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Moment {
     datetime: DateTime<Utc>,
+    instant: Instant,
 }
 
 impl Moment {
     pub fn now() -> Self {
         Self {
             datetime: Utc::now(),
+            instant: Instant::now(),
         }
     }
 
@@ -24,6 +26,18 @@ impl Moment {
         } else {
             None
         }
+    }
+}
+
+impl PartialOrd<Instant> for Moment {
+    fn partial_cmp(&self, other: &Instant) -> Option<std::cmp::Ordering> {
+        self.instant.partial_cmp(other)
+    }
+}
+
+impl PartialEq<Instant> for Moment {
+    fn eq(&self, other: &Instant) -> bool {
+        self.instant.eq(other)
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -37,7 +37,10 @@ use crate::{
 };
 pub use arena::{HierarchicalArena, Index};
 use once_cell::sync::OnceCell;
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    time::{Duration, Instant},
+};
 
 static UI: OnceCell<HierarchicalArena> = OnceCell::new();
 
@@ -53,12 +56,18 @@ pub(crate) struct UIState {
 impl UIState {
     async fn deactivate(&self) {
         let mut data = self.data.write().await;
-        data.active = None;
+        if data.active != None {
+            data.next_redraw_target = RedrawTarget::Now;
+            data.active = None;
+        }
     }
 
     async fn activate(&self, index: Index) {
         let mut data = self.data.write().await;
-        data.active = Some(index);
+        if data.active != Some(index) {
+            data.next_redraw_target = RedrawTarget::Now;
+            data.active = Some(index);
+        }
     }
 
     // async fn focus(&self, index: Index) {
@@ -80,12 +89,102 @@ impl UIState {
         let data = self.data.read().await;
         data.active
     }
+
+    async fn set_needs_redraw(&self) {
+        let mut data = self.data.write().await;
+        data.next_redraw_target = RedrawTarget::Now;
+    }
+
+    async fn clear_redraw_target(&self) {
+        let mut data = self.data.write().await;
+        data.next_redraw_target = RedrawTarget::None;
+    }
+
+    async fn estimate_next_frame(&self, duration: Duration) {
+        self.estimate_next_frame_instant(Instant::now().checked_add(duration).unwrap())
+            .await;
+    }
+
+    async fn estimate_next_frame_instant(&self, instant: Instant) {
+        let mut data = self.data.write().await;
+        match data.next_redraw_target {
+            RedrawTarget::None => {
+                data.next_redraw_target = RedrawTarget::Scheduled(instant);
+            }
+            RedrawTarget::Now => {} // don't schedule, we are already drawing
+            RedrawTarget::Scheduled(existing_instant) => {
+                if instant < existing_instant {
+                    data.next_redraw_target = RedrawTarget::Scheduled(instant);
+                }
+            }
+        }
+    }
+
+    async fn next_redraw_target(&self) -> RedrawTarget {
+        let data = self.data.read().await;
+        data.next_redraw_target
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum RedrawTarget {
+    None,
+    Now,
+    Scheduled(Instant),
+}
+
+impl Default for RedrawTarget {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+pub(crate) enum RedrawSchedule {
+    Now,
+    Scheduled(Instant),
+}
+
+impl RedrawTarget {
+    pub fn next_redraw_instant(&self) -> Option<RedrawSchedule> {
+        match self {
+            Self::None => None,
+            Self::Now => Some(RedrawSchedule::Now),
+            Self::Scheduled(scheduled_for) => Some(RedrawSchedule::Scheduled(*scheduled_for)),
+        }
+    }
+
+    pub fn next_update_instant(&self) -> Option<RedrawSchedule> {
+        match self {
+            Self::None | Self::Now => Some(RedrawSchedule::Now),
+            Self::Scheduled(scheduled_for) => Some(RedrawSchedule::Scheduled(*scheduled_for)),
+        }
+    }
+}
+
+impl RedrawSchedule {
+    pub fn should_redraw(&self) -> bool {
+        self.timeout_target().is_none()
+    }
+
+    pub fn timeout_target(&self) -> Option<Instant> {
+        match self {
+            RedrawSchedule::Now => None,
+            RedrawSchedule::Scheduled(scheduled_for) => {
+                if &Instant::now() > scheduled_for {
+                    None
+                } else {
+                    Some(*scheduled_for)
+                }
+            }
+        }
+    }
 }
 
 #[derive(Default, Debug)]
 struct UIStateData {
     focus: Option<Index>,
     active: Option<Index>,
+    next_redraw_target: RedrawTarget,
 }
 
 pub struct UserInterface<C>
@@ -163,6 +262,8 @@ where
         }
 
         self.last_render_order.reverse();
+
+        self.ui_state.clear_redraw_target().await;
 
         Ok(())
     }
@@ -250,6 +351,10 @@ where
                         node.unhovered(&mut context).await?;
                     }
                 }
+
+                if current_hovered_indicies != starting_hovered_indicies {
+                    self.ui_state.set_needs_redraw().await;
+                }
             }
             Event::MouseWheel { .. } => {} //{todo!("Hook up mouse scroll to hovered nodes"),
             Event::MouseButton { button, state } => match state {
@@ -296,6 +401,14 @@ where
             _ => {}
         }
         Ok(())
+    }
+
+    pub async fn request_redraw(&self) {
+        self.ui_state.set_needs_redraw().await;
+    }
+
+    pub(crate) async fn next_redraw_target(&self) -> RedrawTarget {
+        self.ui_state.next_redraw_target().await
     }
 
     async fn initialize(&self, index: impl Into<Index>, scene: SceneTarget) -> KludgineResult<()> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -146,6 +146,11 @@ impl UIState {
     async fn needs_render(&self) -> bool {
         let data = self.data.read().await;
         data.needs_render
+            || match data.next_redraw_target {
+                RedrawTarget::Never => false,
+                RedrawTarget::None => false,
+                RedrawTarget::Scheduled(scheduled_for) => scheduled_for < Instant::now(),
+            }
     }
 }
 
@@ -192,12 +197,23 @@ impl UpdateSchedule {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 struct UIStateData {
     focus: Option<Index>,
     active: Option<Index>,
     next_redraw_target: RedrawTarget,
     needs_render: bool,
+}
+
+impl Default for UIStateData {
+    fn default() -> Self {
+        Self {
+            needs_render: true,
+            focus: None,
+            active: None,
+            next_redraw_target: RedrawTarget::default(),
+        }
+    }
 }
 
 pub struct UserInterface<C>

--- a/src/ui/context.rs
+++ b/src/ui/context.rs
@@ -10,21 +10,12 @@ pub use self::{
     scene_context::SceneContext,
     styled_context::StyledContext,
 };
+use std::time::{Duration, Instant};
 
 pub struct Context {
     index: Index,
     arena: HierarchicalArena,
     ui_state: UIState,
-}
-
-impl Context {
-    pub fn index(&self) -> Index {
-        self.index
-    }
-
-    pub fn entity<T: InteractiveComponent>(&self) -> Entity<T> {
-        Entity::new(self.index)
-    }
 }
 
 impl Context {
@@ -38,6 +29,14 @@ impl Context {
             arena,
             ui_state,
         }
+    }
+
+    pub fn index(&self) -> Index {
+        self.index
+    }
+
+    pub fn entity<T: InteractiveComponent>(&self) -> Entity<T> {
+        Entity::new(self.index)
     }
 
     pub async fn set_parent<I: Into<Index>>(&self, parent: Option<I>) {
@@ -97,5 +96,17 @@ impl Context {
     pub async fn set_style_sheet(&self, sheet: StyleSheet) {
         let node = self.arena.get(self.index).await.unwrap();
         node.set_style_sheet(sheet).await
+    }
+
+    pub async fn set_needs_redraw(&self) {
+        self.ui_state.set_needs_redraw().await;
+    }
+
+    pub async fn estimate_next_frame(&self, duration: Duration) {
+        self.ui_state.estimate_next_frame(duration).await;
+    }
+
+    pub async fn estimate_next_frame_instant(&self, instant: Instant) {
+        self.ui_state.estimate_next_frame_instant(instant).await;
     }
 }

--- a/src/ui/image.rs
+++ b/src/ui/image.rs
@@ -82,21 +82,25 @@ impl InteractiveComponent for Image {
 
     async fn receive_input(
         &mut self,
-        _context: &mut Context,
+        context: &mut Context,
         command: Self::Input,
     ) -> KludgineResult<()> {
         match command {
             ImageCommand::SetSprite(sprite) => {
+                context.set_needs_redraw().await;
                 self.sprite = sprite;
             }
             ImageCommand::SetTag(tag) => {
+                context.set_needs_redraw().await;
                 self.sprite.set_current_tag(tag).await?;
                 self.options.override_frame = None;
             }
             ImageCommand::SetAlpha(alpha) => {
+                context.set_needs_redraw().await;
                 self.options.alpha = alpha;
             }
             ImageCommand::SetOverrideFrame { tag, frame } => {
+                context.set_needs_redraw().await;
                 self.sprite.set_current_tag(tag).await?;
                 self.options.override_frame = Some(frame);
             }
@@ -121,9 +125,9 @@ impl Component for Image {
 
                 let frame_index = match override_frame {
                     OverrideFrame::Index(index) => *index,
-                    OverrideFrame::Percent(percent) => {
-                        (frames.frames.len() as f32 * *percent) as usize
-                    }
+                    OverrideFrame::Percent(percent) => ((frames.frames.len() as f32 * percent)
+                        .round() as usize)
+                        .min(frames.frames.len() - 1),
                 };
 
                 Some(frames.frames[frame_index].source.clone())

--- a/src/ui/image.rs
+++ b/src/ui/image.rs
@@ -128,11 +128,17 @@ impl Component for Image {
 
                 Some(frames.frames[frame_index].source.clone())
             }
-            None => Some(
-                self.sprite
+            None => Some({
+                let frame = self
+                    .sprite
                     .get_frame(context.scene().elapsed().await)
-                    .await?,
-            ),
+                    .await?;
+                if let Some(remaining_duration) = self.sprite.remaining_frame_duration().await? {
+                    context.estimate_next_frame(remaining_duration).await;
+                }
+
+                frame
+            }),
         };
         Ok(())
     }

--- a/src/ui/label.rs
+++ b/src/ui/label.rs
@@ -28,12 +28,13 @@ impl InteractiveComponent for Label {
 
     async fn receive_input(
         &mut self,
-        _context: &mut Context,
+        context: &mut Context,
         message: Self::Input,
     ) -> KludgineResult<()> {
         match message {
             LabelCommand::SetValue(new_value) => {
                 self.value = new_value;
+                context.set_needs_redraw().await;
             }
         }
         Ok(())

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -5,10 +5,7 @@ use super::{
     math::{Pixels, Point, Points, Size},
     runtime::Runtime,
     scene::{Scene, SceneTarget},
-    ui::{
-        global_arena, InteractiveComponent, NodeData, NodeDataWindowExt, RedrawTarget,
-        UserInterface,
-    },
+    ui::{global_arena, InteractiveComponent, NodeData, NodeDataWindowExt, UserInterface},
     KludgineError, KludgineHandle, KludgineResult,
 };
 use async_trait::async_trait;

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -3,23 +3,23 @@ use super::{
     event::{DeviceId, ElementState, MouseButton, MouseScrollDelta, TouchPhase, VirtualKeyCode},
     frame::Frame,
     math::{Pixels, Point, Points, Size},
-    runtime::{Runtime, FRAME_DURATION},
+    runtime::Runtime,
     scene::{Scene, SceneTarget},
-    ui::{global_arena, InteractiveComponent, NodeData, NodeDataWindowExt, UserInterface},
+    ui::{
+        global_arena, InteractiveComponent, NodeData, NodeDataWindowExt, RedrawTarget,
+        UserInterface,
+    },
     KludgineError, KludgineHandle, KludgineResult,
 };
 use async_trait::async_trait;
 
-use crossbeam::{
-    atomic::AtomicCell,
-    channel::{unbounded, Receiver, Sender, TryRecvError},
-    sync::ShardedLock,
-};
+use crossbeam::{atomic::AtomicCell, sync::ShardedLock};
 use lazy_static::lazy_static;
 use rgx::core::*;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 use futures::executor::block_on;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc};
 use winit::{
     event::{Event as WinitEvent, WindowEvent as WinitWindowEvent},
     window::{Window as WinitWindow, WindowBuilder as WinitWindowBuilder, WindowId},
@@ -61,7 +61,7 @@ impl EventStatus {
 }
 
 /// An Event from a device
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct InputEvent {
     /// The device that triggered this event
     pub device_id: DeviceId,
@@ -70,7 +70,7 @@ pub struct InputEvent {
 }
 
 /// An input Event
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum Event {
     /// A keyboard event
     Keyboard {
@@ -211,7 +211,7 @@ where
 }
 
 lazy_static! {
-    static ref WINDOW_CHANNELS: KludgineHandle<HashMap<WindowId, Sender<WindowMessage>>> =
+    static ref WINDOW_CHANNELS: KludgineHandle<HashMap<WindowId, UnboundedSender<WindowMessage>>> =
         KludgineHandle::new(HashMap::new());
 }
 
@@ -242,34 +242,39 @@ impl WindowMessage {
     }
 }
 
+#[derive(Debug)]
 pub(crate) enum WindowEvent {
     CloseRequested,
     Resize { size: Size, scale_factor: f32 },
     Input(InputEvent),
+    RedrawRequested,
 }
 
 pub(crate) struct RuntimeWindow {
     window: winit::window::Window,
-    receiver: Receiver<WindowMessage>,
-    event_sender: Sender<WindowEvent>,
+    receiver: UnboundedReceiver<WindowMessage>,
+    event_sender: UnboundedSender<WindowEvent>,
     last_known_size: Size,
     last_known_scale_factor: f32,
     keep_running: Arc<AtomicCell<bool>>,
 }
 
 impl RuntimeWindow {
-    pub(crate) fn open<T>(window_receiver: Receiver<WinitWindow>, app_window: T)
-    where
+    pub(crate) async fn open<T>(
+        mut window_receiver: tokio::sync::mpsc::Receiver<WinitWindow>,
+        app_window: T,
+    ) where
         T: Window + Sized + 'static,
     {
         let window = window_receiver
             .recv()
+            .await
             .expect("Error receiving winit::window");
         let window_id = window.id();
         let renderer = Renderer::new(&window).expect("Error creating renderer for window");
 
-        let (message_sender, message_receiver) = unbounded();
-        let (event_sender, event_receiver) = unbounded();
+        let (message_sender, message_receiver) = unbounded_channel();
+        let (event_sender, event_receiver) = unbounded_channel();
 
         let keep_running = Arc::new(AtomicCell::new(true));
         let mut frame_synchronizer = FrameRenderer::run(
@@ -284,7 +289,7 @@ impl RuntimeWindow {
         });
 
         {
-            let mut channels = block_on(WINDOW_CHANNELS.write());
+            let mut channels = WINDOW_CHANNELS.write().await;
             channels.insert(window_id, message_sender);
         }
 
@@ -318,10 +323,52 @@ impl RuntimeWindow {
         Ok(false)
     }
 
+    async fn next_window_event(
+        event_receiver: &mut UnboundedReceiver<WindowEvent>,
+        next_redraw_target: RedrawTarget,
+    ) -> KludgineResult<Option<WindowEvent>> {
+        if let Some(redraw_at) = next_redraw_target.next_update_instant() {
+            let timeout_target = redraw_at.timeout_target();
+            if let Some(timeout_target) = timeout_target {
+                match tokio::time::timeout_at(
+                    tokio::time::Instant::from_std(timeout_target),
+                    event_receiver.recv(),
+                )
+                .await
+                {
+                    Ok(Some(event)) => Ok(Some(event)),
+                    Ok(None) => Err(KludgineError::InternalWindowMessageSendError(
+                        "Window channel closed".to_owned(),
+                    )),
+                    Err(_) => Ok(None),
+                }
+            } else {
+                println!("No sleep receiving events");
+                match event_receiver.try_recv() {
+                    Ok(event) => Ok(Some(event)),
+                    Err(tokio::sync::mpsc::error::TryRecvError::Empty) => Ok(None),
+                    Err(tokio::sync::mpsc::error::TryRecvError::Closed) => {
+                        Err(KludgineError::InternalWindowMessageSendError(
+                            "Window channel closed".to_owned(),
+                        ))
+                    }
+                }
+            }
+        } else {
+            println!("Sleeping forever for events");
+            match event_receiver.recv().await {
+                Some(event) => Ok(Some(event)),
+                None => Err(KludgineError::InternalWindowMessageSendError(
+                    "Window channel closed".to_owned(),
+                )),
+            }
+        }
+    }
+
     async fn window_loop<T>(
         id: WindowId,
         mut frame_synchronizer: FrameSynchronizer,
-        event_receiver: Receiver<WindowEvent>,
+        mut event_receiver: UnboundedReceiver<WindowEvent>,
         window: T,
     ) -> KludgineResult<()>
     where
@@ -331,15 +378,16 @@ impl RuntimeWindow {
         let mut ui = UserInterface::new(window, SceneTarget::Scene(scene.clone())).await?;
         #[cfg(feature = "bundled-fonts-enabled")]
         scene.register_bundled_fonts().await;
-        let mut interval = tokio::time::interval(Duration::from_nanos(FRAME_DURATION));
         loop {
-            while let Some(event) = match event_receiver.try_recv() {
-                Ok(event) => Some(event),
-                Err(err) => match err {
-                    TryRecvError::Empty => None,
-                    TryRecvError::Disconnected => return Ok(()),
-                },
-            } {
+            while let Some(event) =
+                match Self::next_window_event(&mut event_receiver, ui.next_redraw_target().await)
+                    .await
+                {
+                    Ok(event) => event,
+                    Err(_) => return Ok(()),
+                }
+            {
+                println!("Got event {:?}", event);
                 match event {
                     WindowEvent::Resize { size, scale_factor } => {
                         scene
@@ -373,6 +421,9 @@ impl RuntimeWindow {
                             }
                         }
                     }
+                    WindowEvent::RedrawRequested => {
+                        ui.request_redraw().await;
+                    }
                 }
             }
 
@@ -388,26 +439,35 @@ impl RuntimeWindow {
             }
 
             if scene.size().await.area().to_f32() > 0.0 {
-                scene.start_frame().await;
-                {
-                    let target = SceneTarget::Scene(scene.clone());
-                    ui.update(&target).await?;
+                println!("Calling application updates");
+                let now = scene.start_frame().await;
+
+                let target = SceneTarget::Scene(scene.clone());
+                ui.update(&target).await?;
+
+                let render = match ui.next_redraw_target().await.next_redraw_instant() {
+                    Some(schedule) => schedule.should_redraw(),
+                    None => false,
+                };
+
+                if render {
+                    println!("Rendering {:?}", now);
                     ui.render(&target).await?;
-                }
-                if let Some(mut frame) = frame_synchronizer.try_take() {
-                    frame.update(&scene).await;
-                    frame_synchronizer.relinquish(frame).await;
-                } else {
+
+                    if let Some(mut frame) = frame_synchronizer.try_take() {
+                        frame.update(&scene).await;
+                        frame_synchronizer.relinquish(frame).await;
+                    } else {
+                    }
                 }
             }
-            interval.tick().await;
         }
     }
 
     async fn window_main<T>(
         id: WindowId,
         frame_synchronizer: FrameSynchronizer,
-        event_receiver: Receiver<WindowEvent>,
+        event_receiver: UnboundedReceiver<WindowEvent>,
         window: T,
     ) where
         T: Window,
@@ -426,11 +486,12 @@ impl RuntimeWindow {
         let mut windows = WINDOWS.write().unwrap();
 
         if let WinitEvent::WindowEvent { window_id, event } = event {
-            // println!("Received event {:?} for window {:?}", event, window_id);
-            // println!("Current windows: {:#?}", windows.borrow().keys());
             if let Some(window) = windows.get_mut(&window_id) {
-                // println!("Sending event to window {:?}", window.window.id());
                 window.process_event(event);
+            }
+        } else if let WinitEvent::RedrawRequested(window_id) = event {
+            if let Some(window) = windows.get_mut(&window_id) {
+                window.request_redraw();
             }
         }
 
@@ -453,6 +514,12 @@ impl RuntimeWindow {
                 }
             }
         }
+    }
+
+    pub(crate) fn request_redraw(&self) {
+        self.event_sender
+            .send(WindowEvent::RedrawRequested)
+            .unwrap_or_default();
     }
 
     pub(crate) fn process_event(&mut self, event: &WinitWindowEvent) {

--- a/src/window/renderer.rs
+++ b/src/window/renderer.rs
@@ -39,10 +39,6 @@ impl FrameSynchronizer {
         self.receiver.recv().await.unwrap_or_default()
     }
 
-    pub fn try_take(&mut self) -> Option<Frame> {
-        self.receiver.try_recv().ok()
-    }
-
     pub async fn relinquish(&mut self, frame: Frame) {
         // Ignoring the error because if the sender/receiver is disconnected
         // the window is closing and we should just ignore the error and let


### PR DESCRIPTION
Fixes #8 

After some long-running back-of-the-mind ruminations, I've implemented a mechanism for enabling low-CPU usage applications to be written as well as windows that have an "ideal" polling rate.

* `Window` trait now has a `target_fps(&self) -> Option<u16>` method which by default returns `None`. If you want your Window to be drawn at a regular interval, you can implement this method yourself and specify your target fps.
* If you're approaching your app from a standpoint of minimizing CPU usage, you'll want to familiarize yourself with the `Context::set_needs_redraw(&self)`, `Context::estimate_next_frame(Duration)`, and `Context::estimate_next_frame_instant(Instant)`. These methods schedule the next redraw.

Regardless of method, as much time as can be yielded back to the OS will be. This means the Simple example idles with no CPU usage outside of any events that the OS sends to the app.