### PR TITLE
Support clipping non-rotated sprites

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub mod prelude {
             ScreenScale, Size, SizeExt, Surround, Unknown, Vector,
         },
         runtime::Runtime,
-        scene::Scene,
+        scene::{Scene, Target},
         shape::*,
         sprite::{
             AnimationMode, Sprite, SpriteAnimation, SpriteAnimations, SpriteCollection,

--- a/src/shape/circle.rs
+++ b/src/shape/circle.rs
@@ -1,6 +1,6 @@
 use crate::{
     math::{Length, Point, Raw, Scale, Scaled},
-    scene::Scene,
+    scene::Target,
     shape::{Fill, Stroke},
     KludgineError, KludgineResult,
 };
@@ -14,7 +14,7 @@ impl Circle<Scaled> {
     pub(crate) async fn translate_and_convert_to_device(
         &self,
         location: Point<f32, Scaled>,
-        scene: &Scene,
+        scene: &Target,
     ) -> Circle<Raw> {
         let effective_scale = scene.scale_factor().await;
         let center = (location + self.center.to_vector()) * effective_scale;

--- a/src/shape/geometry.rs
+++ b/src/shape/geometry.rs
@@ -1,6 +1,6 @@
 use crate::{
     math::{Point, Raw, Scale, Scaled},
-    scene::Scene,
+    scene::Target,
     shape::{circle::Circle, Fill, Path, Stroke},
     KludgineResult,
 };
@@ -31,7 +31,7 @@ impl ShapeGeometry<Scaled> {
     pub(crate) async fn translate_and_convert_to_device(
         &self,
         location: Point<f32, Scaled>,
-        scene: &Scene,
+        scene: &Target,
     ) -> ShapeGeometry<Raw> {
         match self {
             Self::Empty => ShapeGeometry::Empty,

--- a/src/shape/mod.rs
+++ b/src/shape/mod.rs
@@ -8,7 +8,7 @@ mod stroke;
 pub use self::{batch::*, fill::*, path::*, stroke::*};
 use crate::{
     math::{Point, Raw, Rect, Scaled},
-    scene::{Element, Scene},
+    scene::{Element, Target},
     KludgineResult,
 };
 use circle::Circle;
@@ -80,7 +80,7 @@ where
 }
 
 impl Shape<Scaled> {
-    pub async fn render_at(&self, location: Point<f32, Scaled>, scene: &Scene) {
+    pub async fn render_at(&self, location: Point<f32, Scaled>, scene: &Target) {
         let translated = self.convert_from_user_to_device(location, scene).await;
         scene.push_element(Element::Shape(translated)).await
     }
@@ -88,7 +88,7 @@ impl Shape<Scaled> {
     async fn convert_from_user_to_device(
         &self,
         location: Point<f32, Scaled>,
-        scene: &Scene,
+        scene: &Target,
     ) -> Shape<Raw> {
         Shape {
             geometry: self

--- a/src/shape/path.rs
+++ b/src/shape/path.rs
@@ -1,6 +1,6 @@
 use crate::{
     math::{Point, Raw, Scale, Scaled, ScreenScale},
-    scene::Scene,
+    scene::Target,
     shape::{Fill, Stroke},
     KludgineError, KludgineResult,
 };
@@ -78,7 +78,7 @@ impl Path<Scaled> {
     pub(crate) async fn translate_and_convert_to_device(
         &self,
         location: Point<f32, Scaled>,
-        scene: &Scene,
+        scene: &Target,
     ) -> Path<Raw> {
         let effective_scale = scene.scale_factor().await;
         let mut events = Vec::new();

--- a/src/sprite/batch.rs
+++ b/src/sprite/batch.rs
@@ -1,16 +1,25 @@
-use crate::{math::Size, sprite::RenderedSprite};
+use crate::{
+    math::{Raw, Rect, Size},
+    sprite::RenderedSprite,
+};
 
 pub(crate) struct Batch {
     pub size: Size<u32>,
+    pub clipping_rect: Option<Rect<u32, Raw>>,
     pub loaded_texture_id: u64,
     pub sprites: Vec<RenderedSprite>,
 }
 
 impl Batch {
-    pub fn new(loaded_texture_id: u64, size: Size<u32>) -> Self {
+    pub fn new(
+        loaded_texture_id: u64,
+        size: Size<u32>,
+        clipping_rect: Option<Rect<u32, Raw>>,
+    ) -> Self {
         Self {
             loaded_texture_id,
             size,
+            clipping_rect,
             sprites: Vec::new(),
         }
     }

--- a/src/sprite/source.rs
+++ b/src/sprite/source.rs
@@ -1,6 +1,6 @@
 use crate::{
     math::{Point, Raw, Rect, Scaled, Size},
-    scene::{Element, Scene},
+    scene::{Element, Target},
     sprite::{RenderedSprite, SpriteRotation},
     texture::Texture,
 };
@@ -102,7 +102,7 @@ impl SpriteSource {
 
     pub async fn render_at(
         &self,
-        scene: &Scene,
+        scene: &Target,
         location: Point<f32, Scaled>,
         rotation: SpriteRotation<Scaled>,
     ) {
@@ -112,7 +112,7 @@ impl SpriteSource {
 
     pub async fn render_within(
         &self,
-        scene: &Scene,
+        scene: &Target,
         bounds: Rect<f32, Scaled>,
         rotation: SpriteRotation<Scaled>,
     ) {
@@ -121,7 +121,7 @@ impl SpriteSource {
 
     pub async fn render_within_box(
         &self,
-        scene: &Scene,
+        scene: &Target,
         bounds: Box2D<f32, Scaled>,
         rotation: SpriteRotation<Scaled>,
     ) {
@@ -131,7 +131,7 @@ impl SpriteSource {
 
     pub async fn render_at_with_alpha(
         &self,
-        scene: &Scene,
+        scene: &Target,
         location: Point<f32, Scaled>,
         rotation: SpriteRotation<Scaled>,
         alpha: f32,
@@ -147,7 +147,7 @@ impl SpriteSource {
 
     pub async fn render_with_alpha(
         &self,
-        scene: &Scene,
+        scene: &Target,
         bounds: Rect<f32, Scaled>,
         rotation: SpriteRotation<Scaled>,
         alpha: f32,
@@ -158,7 +158,7 @@ impl SpriteSource {
 
     pub async fn render_with_alpha_in_box(
         &self,
-        scene: &Scene,
+        scene: &Target,
         bounds: Box2D<f32, Scaled>,
         rotation: SpriteRotation<Scaled>,
         alpha: f32,
@@ -175,18 +175,16 @@ impl SpriteSource {
 
     pub async fn render_raw_with_alpha_in_box(
         &self,
-        scene: &Scene,
+        scene: &Target,
         bounds: Box2D<f32, Raw>,
         rotation: SpriteRotation<Raw>,
         alpha: f32,
     ) {
         scene
-            .push_element(Element::Sprite(RenderedSprite::new(
-                bounds,
-                rotation,
-                alpha,
-                self.clone(),
-            )))
+            .push_element(Element::Sprite {
+                sprite: RenderedSprite::new(bounds, rotation, alpha, self.clone()),
+                clip: scene.clipping_rect(),
+            })
             .await;
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,6 +1,6 @@
 use crate::{
     math::{Raw, Scaled},
-    scene::Scene,
+    scene::Target,
 };
 use euclid::Scale;
 use std::{
@@ -163,7 +163,7 @@ impl<Unit: Send + Sync + Debug + 'static> Style<Unit> {
 }
 
 impl Style<Scaled> {
-    pub async fn effective_style(&self, scene: &Scene) -> Style<Raw> {
+    pub async fn effective_style(&self, scene: &Target) -> Style<Raw> {
         let mut style = Style::new();
         let scale = scene.scale_factor().await;
 

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -4,7 +4,7 @@ use crate::style::{ColorPair, FallbackStyle};
 
 use super::{
     math::{Point, Raw, Scaled},
-    scene::Scene,
+    scene::Target,
     style::Style,
     KludgineResult,
 };
@@ -55,13 +55,13 @@ where
         }
     }
 
-    pub async fn wrap(&self, scene: &Scene, options: TextWrap) -> KludgineResult<PreparedText> {
+    pub async fn wrap(&self, scene: &Target, options: TextWrap) -> KludgineResult<PreparedText> {
         TextWrapper::wrap(self, scene, options).await // TODO cache result
     }
 
     pub async fn render_at(
         &self,
-        scene: &Scene,
+        scene: &Target,
         location: Point<f32, Scaled>,
         wrapping: TextWrap,
     ) -> KludgineResult<()> {
@@ -70,7 +70,7 @@ where
 
     pub async fn render_baseline_at(
         &self,
-        scene: &Scene,
+        scene: &Target,
         location: Point<f32, Scaled>,
         wrapping: TextWrap,
     ) -> KludgineResult<()> {
@@ -79,7 +79,7 @@ where
 
     async fn render_core(
         &self,
-        scene: &Scene,
+        scene: &Target,
         location: Point<f32, Scaled>,
         offset_baseline: bool,
         wrapping: TextWrap,

--- a/src/text/prepared.rs
+++ b/src/text/prepared.rs
@@ -1,7 +1,7 @@
 use crate::{
     color::Color,
     math::{Pixels, Point, Points, Raw, Scaled, ScreenScale, Size, SizeExt, Vector},
-    scene::{Element, Scene},
+    scene::{Element, Target},
     style::Alignment,
     text::Font,
     KludgineResult,
@@ -52,7 +52,7 @@ impl PreparedText {
 
     pub async fn render(
         &self,
-        scene: &Scene,
+        scene: &Target,
         location: Point<f32, Scaled>,
         offset_baseline: bool,
     ) -> KludgineResult<Points> {
@@ -71,7 +71,10 @@ impl PreparedText {
                     + span.location.to_vector() / effective_scale_factor)
                     * effective_scale_factor;
                 scene
-                    .push_element(Element::Text(span.translate(location)))
+                    .push_element(Element::Text {
+                        span: span.translate(location),
+                        clip: scene.clipping_rect(),
+                    })
                     .await;
             }
             current_line_baseline += (metrics.line_gap - metrics.descent) / effective_scale_factor;

--- a/src/text/wrap.rs
+++ b/src/text/wrap.rs
@@ -1,6 +1,6 @@
 use crate::{
     math::{max_f, min_f, Pixels, PointExt, Points, Raw},
-    scene::Scene,
+    scene::Target,
     style::{Alignment, ColorPair, FallbackStyle},
     text::{PreparedLine, PreparedSpan, PreparedText, Text},
     KludgineResult,
@@ -13,7 +13,7 @@ pub(crate) use self::{measured::*, tokenizer::*};
 
 pub struct TextWrapper {
     options: TextWrap,
-    scene: Scene,
+    scene: Target,
     prepared_text: PreparedText,
 }
 
@@ -124,7 +124,7 @@ impl TextWrapState {
 impl TextWrapper {
     pub async fn wrap<TextColor: Into<ColorPair> + FallbackStyle<Raw>>(
         text: &Text<TextColor>,
-        scene: &Scene,
+        scene: &Target,
         options: TextWrap,
     ) -> KludgineResult<PreparedText> {
         TextWrapper {
@@ -231,7 +231,7 @@ mod tests {
     use super::*;
     use crate::{
         math::{Scaled, ScreenScale},
-        scene::Scene,
+        scene::{Scene, Target},
         style::{theme::Minimal, FontSize, Style, TextColor},
         text::Span,
     };
@@ -240,7 +240,7 @@ mod tests {
     /// This test should have "This line should " be on the first line and "wrap" on the second
     async fn wrap_one_word() {
         for &scale in &[1f32, 2.] {
-            let mut scene = Scene::new(Box::new(Minimal::default()));
+            let mut scene = Target::from(Scene::new(Box::new(Minimal::default())));
             scene.set_scale_factor(ScreenScale::new(scale)).await;
             scene.register_bundled_fonts().await;
             let wrap = Text::<TextColor>::new(vec![Span::new(
@@ -270,7 +270,7 @@ mod tests {
     #[async_test]
     /// This test should have "This line should " be on the first line and "wrap" on the second
     async fn wrap_one_word_different_span() {
-        let scene = Scene::new(Box::new(Minimal::default()));
+        let scene = Target::from(Scene::new(Box::new(Minimal::default())));
         scene.register_bundled_fonts().await;
 
         let first_style = Style::new()

--- a/src/text/wrap/measured.rs
+++ b/src/text/wrap/measured.rs
@@ -1,6 +1,6 @@
 use crate::{
     math::Raw,
-    scene::Scene,
+    scene::Target,
     style::{ColorPair, FallbackStyle},
     text::{ParserStatus, PreparedSpan, SpanGroup, Text, Token, Tokenizer},
     KludgineResult,
@@ -99,7 +99,7 @@ impl TextMeasureState {
 impl MeasuredText {
     pub async fn new<TextColor: Into<ColorPair> + FallbackStyle<Raw>>(
         text: &Text<TextColor>,
-        scene: &Scene,
+        scene: &Target,
     ) -> KludgineResult<Self> {
         let mut measured = Self { groups: Vec::new() };
 
@@ -111,7 +111,7 @@ impl MeasuredText {
     async fn measure_text<TextColor: Into<ColorPair> + FallbackStyle<Raw>>(
         &mut self,
         text: &Text<TextColor>,
-        scene: &Scene,
+        scene: &Target,
     ) -> KludgineResult<()> {
         let mut state = TextMeasureState {
             current_group: None,

--- a/src/text/wrap/tokenizer.rs
+++ b/src/text/wrap/tokenizer.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::{
     math::{Pixels, Raw, Scaled},
-    scene::Scene,
+    scene::Target,
     style::{ColorPair, FallbackStyle, FontFamily, FontSize, FontStyle, Style, Weight},
     text::{font::Font, prepared::GlyphInfo, PreparedSpan, Text},
     KludgineResult,
@@ -83,7 +83,7 @@ where
     async fn emit_token_if_needed(
         &mut self,
         scale: euclid::Scale<f32, Scaled, Raw>,
-        scene: &Scene,
+        scene: &Target,
     ) -> Option<Token> {
         if self.glyphs.is_empty() {
             None
@@ -122,7 +122,7 @@ impl Tokenizer {
     pub(crate) async fn prepare_spans<TextColor: Into<ColorPair> + FallbackStyle<Raw>>(
         mut self,
         text: &Text<TextColor>,
-        scene: &Scene,
+        scene: &Target,
     ) -> KludgineResult<Vec<Token>> {
         let scale = scene.scale_factor().await;
         let mut current_offset = 0usize;

--- a/src/tilemap/mod.rs
+++ b/src/tilemap/mod.rs
@@ -1,10 +1,13 @@
 use super::{
     math::{Point, PointExt, Scaled, Size, SizeExt},
-    scene::Scene,
+    scene::Target,
     sprite::{Sprite, SpriteRotation},
     KludgineResult,
 };
-use crate::{math::Raw, math::Unknown, sprite::SpriteSource};
+use crate::{
+    math::{Raw, Unknown},
+    sprite::SpriteSource,
+};
 use async_trait::async_trait;
 use euclid::{Box2D, Length, Scale};
 use std::{
@@ -37,13 +40,13 @@ where
         self.stagger = Some(stagger);
     }
 
-    pub async fn draw(&self, scene: &Scene, location: Point<f32, Scaled>) -> KludgineResult<()> {
+    pub async fn draw(&self, scene: &Target, location: Point<f32, Scaled>) -> KludgineResult<()> {
         self.draw_scaled(scene, location, Scale::identity()).await
     }
 
     pub async fn draw_scaled(
         &self,
-        scene: &Scene,
+        scene: &Target,
         location: Point<f32, Scaled>,
         scale: Scale<f32, Unknown, Scaled>,
     ) -> KludgineResult<()> {
@@ -106,7 +109,7 @@ where
         &self,
         tile: Point<i32>,
         destination: Box2D<f32, Raw>,
-        scene: &Scene,
+        scene: &Target,
         elapsed: Option<Duration>,
     ) -> KludgineResult<()> {
         if let Some(tile) = self.provider.get_tile(tile).await {

--- a/src/ui/component.rs
+++ b/src/ui/component.rs
@@ -1,6 +1,6 @@
 use crate::{
     math::{Point, PointExt, Raw, Rect, Scaled, Size, SizeExt},
-    scene::Scene,
+    scene::Target,
     shape::{Fill, Shape},
     style::{BackgroundColor, ColorPair, FallbackStyle, Style, StyleSheet},
     ui::{
@@ -373,7 +373,7 @@ where
     C: InteractiveComponent + 'static,
 {
     components: ThreadsafeAnyMap,
-    scene: Scene,
+    scene: Target,
     parent: Option<Index>,
     style_sheet: StyleSheet,
     interactive: bool,

--- a/src/ui/context.rs
+++ b/src/ui/context.rs
@@ -1,5 +1,5 @@
 use crate::{
-    prelude::Scene,
+    scene::Target,
     style::StyleSheet,
     ui::{Entity, HierarchicalArena, Index, Indexable, InteractiveComponent, Layout, UIState},
 };
@@ -16,7 +16,7 @@ pub struct Context {
     index: Index,
     arena: HierarchicalArena,
     ui_state: UIState,
-    scene: Scene,
+    scene: Target,
 }
 
 impl Context {
@@ -24,7 +24,7 @@ impl Context {
         index: I,
         arena: HierarchicalArena,
         ui_state: UIState,
-        scene: Scene,
+        scene: Target,
     ) -> Self {
         Self {
             index: index.index(),
@@ -38,11 +38,11 @@ impl Context {
         self.index
     }
 
-    pub fn scene(&self) -> &'_ Scene {
+    pub fn scene(&self) -> &'_ Target {
         &self.scene
     }
 
-    pub fn scene_mut(&mut self) -> &'_ mut Scene {
+    pub fn scene_mut(&mut self) -> &'_ mut Target {
         &mut self.scene
     }
 

--- a/src/ui/context/layout_context.rs
+++ b/src/ui/context/layout_context.rs
@@ -1,6 +1,6 @@
 use crate::{
     math::{Point, Raw, Rect, Scaled, Size, Surround},
-    scene::Scene,
+    scene::Target,
     style::Style,
     ui::{
         Context, HierarchicalArena, Index, Indexable, Layout, LayoutSolver, StyledContext, UIState,
@@ -49,7 +49,7 @@ impl LayoutEngine {
         arena: &HierarchicalArena,
         ui_state: &UIState,
         root: Index,
-        scene: &Scene,
+        scene: &Target,
         hovered_indicies: HashSet<Index>,
     ) -> KludgineResult<Self> {
         let mut effective_styles = HashMap::new();
@@ -217,7 +217,7 @@ impl std::ops::DerefMut for LayoutContext {
 impl LayoutContext {
     pub(crate) fn new<I: Indexable>(
         index: I,
-        scene: Scene,
+        scene: Target,
         effective_styles: Arc<HashMap<Index, Style<Raw>>>,
         layout: LayoutEngine,
         arena: HierarchicalArena,

--- a/src/ui/context/styled_context.rs
+++ b/src/ui/context/styled_context.rs
@@ -1,6 +1,6 @@
 use crate::{
     math::{Raw, Scaled, Size},
-    scene::Scene,
+    scene::Target,
     style::Style,
     ui::{Context, HierarchicalArena, Index, Indexable, UIState},
     KludgineError, KludgineResult,
@@ -29,7 +29,7 @@ impl std::ops::DerefMut for StyledContext {
 impl StyledContext {
     pub(crate) fn new<I: Indexable>(
         index: I,
-        scene: Scene,
+        scene: Target,
         effective_styles: Arc<HashMap<Index, Style<Raw>>>,
         arena: HierarchicalArena,
         ui_state: UIState,

--- a/src/ui/layout/absolute.rs
+++ b/src/ui/layout/absolute.rs
@@ -360,7 +360,7 @@ mod tests {
     #[async_test]
     async fn layout_test() -> KludgineResult<()> {
         use crate::{
-            scene::Scene,
+            scene::{Scene, Target},
             style::{theme::Minimal, StyleSheet},
             ui::{
                 Component, HierarchicalArena, Layout, LayoutEngine, LayoutSolver, LayoutSolverExt,
@@ -457,7 +457,7 @@ mod tests {
         arena.set_parent(leaf, Some(child)).await;
         arena.set_parent(child, Some(root)).await;
 
-        let scene = Scene::new(Box::new(Minimal::default()));
+        let scene = Target::from(Scene::new(Box::new(Minimal::default())));
         scene.set_internal_size(Size::new(200., 200.)).await;
         let (event_sender, _) = async_channel::unbounded();
         let engine = LayoutEngine::layout(

--- a/src/ui/legion.rs
+++ b/src/ui/legion.rs
@@ -2,7 +2,7 @@ use crate::{
     math::{Angle, Point, Rect, Scale, Scaled, Unknown},
     prelude::TextWrap,
     runtime::Runtime,
-    scene::Scene,
+    scene::Target,
     shape::Shape,
     sprite::{Sprite, SpriteRotation, SpriteSource},
     style::TextColor,
@@ -352,7 +352,7 @@ trait TypelessTileMap<Unit: 'static>: Send + Sync + Debug + 'static {
     fn as_any(&self) -> &dyn Any;
     async fn draw_scaled(
         &self,
-        scene: &Scene,
+        scene: &Target,
         location: Point<f32, Scaled>,
         scale: Scale<f32, Unknown, Scaled>,
     ) -> KludgineResult<()>;
@@ -370,7 +370,7 @@ pub trait CustomDrawable<Unit: 'static>: Send + Sync + Debug + 'static {
     }
     async fn render(
         &self,
-        scene: &Scene,
+        scene: &Target,
         origin: Point<f32, Scaled>,
         scale: Scale<f32, Unit, Scaled>,
         rotation: Option<Angle>,
@@ -423,7 +423,7 @@ impl<P: TileProvider + Send + Sync + Debug + 'static, Unit: Send + 'static> Type
 {
     async fn draw_scaled(
         &self,
-        scene: &Scene,
+        scene: &Target,
         location: Point<f32, Scaled>,
         scale: Scale<f32, Unknown, Scaled>,
     ) -> KludgineResult<()> {
@@ -775,7 +775,7 @@ pub trait LegionSystemsThread: Sized {
 
     fn spawn<F: FnOnce() -> legion::Resources + Send + Sync + 'static>(
         canvas: crate::ui::Entity<Canvas<Self::Unit, Self::Command>>,
-        scene: &Scene,
+        scene: &Target,
         tick_rate: Duration,
         resource_initializer: F,
     ) -> SystemsHandle<Self::Unit, Self::Command> {

--- a/src/ui/text_field.rs
+++ b/src/ui/text_field.rs
@@ -1,7 +1,7 @@
 use crate::{
     color::Color,
     math::{Pixels, Point, PointExt, Points, Raw, Rect, Scaled, Size, SizeExt, Surround},
-    prelude::Scene,
+    scene::Target,
     shape::{Fill, Shape},
     style::{
         Alignment, ColorPair, FallbackStyle, GenericStyle, Style, StyleComponent,
@@ -530,7 +530,7 @@ impl TextField {
 
     async fn position_for_location(
         &self,
-        scene: &Scene,
+        scene: &Target,
         location: Point<f32, Scaled>,
     ) -> Option<RichTextPosition> {
         if let Some(prepared) = &self.prepared {
@@ -583,7 +583,7 @@ impl TextField {
 
     async fn character_rect_for_position(
         &self,
-        scene: &Scene,
+        scene: &Target,
         position: RichTextPosition,
     ) -> Option<Rect<f32, Scaled>> {
         let mut last_location = None;

--- a/src/window/frame.rs
+++ b/src/window/frame.rs
@@ -43,7 +43,7 @@ impl FrameBatch {
         !self.is_shape()
     }
 
-    fn sprite_batch(&mut self) -> Option<&'_ mut sprite::Batch> {
+    fn sprite_batch(&self) -> Option<&'_ sprite::Batch> {
         if let FrameBatch::Sprite(batch) = self {
             Some(batch)
         } else {
@@ -51,7 +51,23 @@ impl FrameBatch {
         }
     }
 
-    fn shape_batch(&mut self) -> Option<&'_ mut shape::Batch> {
+    // fn shape_batch(&self) -> Option<&'_ shape::Batch> {
+    //     if let FrameBatch::Shape(batch) = self {
+    //         Some(batch)
+    //     } else {
+    //         None
+    //     }
+    // }
+
+    fn sprite_batch_mut(&mut self) -> Option<&'_ mut sprite::Batch> {
+        if let FrameBatch::Sprite(batch) = self {
+            Some(batch)
+        } else {
+            None
+        }
+    }
+
+    fn shape_batch_mut(&mut self) -> Option<&'_ mut shape::Batch> {
         if let FrameBatch::Shape(batch) = self {
             Some(batch)
         } else {
@@ -87,6 +103,13 @@ impl Frame {
                         || current_texture_id.as_ref().unwrap() != &texture.id
                         || current_batch.is_none()
                         || !current_batch.as_ref().unwrap().is_sprite()
+                        || current_batch
+                            .as_ref()
+                            .unwrap()
+                            .sprite_batch()
+                            .unwrap()
+                            .clipping_rect
+                            != *clip
                     {
                         self.commit_batch(current_batch);
                         current_texture_id = Some(texture.id);
@@ -107,7 +130,7 @@ impl Frame {
                         )));
                     }
 
-                    let current_batch = current_batch.as_mut().unwrap().sprite_batch().unwrap();
+                    let current_batch = current_batch.as_mut().unwrap().sprite_batch_mut().unwrap();
                     current_batch.sprites.push(sprite_handle.clone());
                 }
                 Element::Text { span, clip } => {
@@ -126,7 +149,7 @@ impl Frame {
                         current_batch = Some(FrameBatch::Shape(shape::Batch::default()));
                     }
 
-                    let current_batch = current_batch.as_mut().unwrap().shape_batch().unwrap();
+                    let current_batch = current_batch.as_mut().unwrap().shape_batch_mut().unwrap();
                     current_batch.add(shape.clone());
                 }
             }

--- a/src/window/renderer.rs
+++ b/src/window/renderer.rs
@@ -258,7 +258,8 @@ impl FrameRenderer {
                         }
                     }
                     FrameCommand::DrawBatch(batch) => {
-                        let mut gpu_batch = sprite::GpuBatch::new(batch.size.cast_unit());
+                        let mut gpu_batch =
+                            sprite::GpuBatch::new(batch.size.cast_unit(), batch.clipping_rect);
                         for sprite_handle in batch.sprites.iter() {
                             gpu_batch.add_sprite(sprite_handle.clone());
                         }
@@ -273,10 +274,10 @@ impl FrameRenderer {
                         // pass.set_easy_pipeline(&self.shape_pipeline);
                         // prepared_shape.draw(&mut pass);
                     }
-                    FrameCommand::DrawText { text } => {
+                    FrameCommand::DrawText { text, clip } => {
                         if let Some(loaded_font) = engine_frame.fonts.get(&text.data.font.id) {
                             if let Some(texture) = loaded_font.texture.as_ref() {
-                                let mut batch = sprite::GpuBatch::new(texture.size);
+                                let mut batch = sprite::GpuBatch::new(texture.size, clip);
                                 for (uv_rect, screen_rect) in
                                     text.data.glyphs.iter().filter_map(|g| {
                                         loaded_font.cache.rect_for(0, &g.glyph).ok().flatten()

--- a/src/window/renderer.rs
+++ b/src/window/renderer.rs
@@ -258,8 +258,10 @@ impl FrameRenderer {
                         }
                     }
                     FrameCommand::DrawBatch(batch) => {
-                        let mut gpu_batch =
-                            sprite::GpuBatch::new(batch.size.cast_unit(), batch.clipping_rect);
+                        let mut gpu_batch = sprite::GpuBatch::new(
+                            batch.size.cast_unit(),
+                            batch.clipping_rect.map(|r| r.to_box2d()),
+                        );
                         for sprite_handle in batch.sprites.iter() {
                             gpu_batch.add_sprite(sprite_handle.clone());
                         }
@@ -277,7 +279,8 @@ impl FrameRenderer {
                     FrameCommand::DrawText { text, clip } => {
                         if let Some(loaded_font) = engine_frame.fonts.get(&text.data.font.id) {
                             if let Some(texture) = loaded_font.texture.as_ref() {
-                                let mut batch = sprite::GpuBatch::new(texture.size, clip);
+                                let mut batch =
+                                    sprite::GpuBatch::new(texture.size, clip.map(|r| r.to_box2d()));
                                 for (uv_rect, screen_rect) in
                                     text.data.glyphs.iter().filter_map(|g| {
                                         loaded_font.cache.rect_for(0, &g.glyph).ok().flatten()

--- a/src/window/runtime_window.rs
+++ b/src/window/runtime_window.rs
@@ -1,7 +1,8 @@
 use crate::{
     math::{Pixels, Point, ScreenScale, Size},
+    prelude::Scene,
     runtime::Runtime,
-    scene::Scene,
+    scene::Target,
     style::theme::SystemTheme,
     ui::{global_arena, NodeData, NodeDataWindowExt, UserInterface},
     window::{
@@ -243,13 +244,13 @@ impl RuntimeWindow {
             if scene.size().await.area() > 0.0 {
                 scene.start_frame().await;
 
-                ui.update(&scene, target_fps).await?;
+                ui.update(&Target::from(scene.clone()), target_fps).await?;
 
                 if ui.needs_render().await {
                     ui.render().await?;
 
                     let mut frame = frame_synchronizer.take().await;
-                    frame.update(&scene).await;
+                    frame.update(&Target::from(scene.clone())).await;
                     frame_synchronizer.relinquish(frame).await;
                 }
             }


### PR DESCRIPTION
Adds clipping rect state management to sprite and shape pipelines, but only adds support for honoring it to the sprite pipeline. When rotations are detected to be partially clipped, a warning is emitted and the sprite is allowed to render.

Refs #11 