### PR TITLE
add non-mutating Sprite::current_frame function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `Sprite::current_frame` immutably retrieves the current frame. This
+  is equivalent to calling `Sprite::get_frame(None)` but can be used
+  in non-mutable settings.
+
 ## v0.1.0-dev.3
 
 ### Changes

--- a/core/src/sprite.rs
+++ b/core/src/sprite.rs
@@ -330,7 +330,13 @@ impl Sprite {
             }
         }
 
-        self.with_current_frame(|frame| frame.source.clone())
+	self.current_frame()
+    }
+
+    /// Retrieve the current animation frame, if set and valid.
+    #[inline]
+    pub fn current_frame(&self) -> crate::Result<SpriteSource> {
+         self.with_current_frame(|frame| frame.source.clone())
     }
 
     /// Returns the amount of time remaining until the next frame is due to be
@@ -393,6 +399,7 @@ impl Sprite {
         })
     }
 
+    /// If tag is valid, invoke `f` with the current animation frame.
     fn with_current_frame<F, R>(&self, f: F) -> crate::Result<R>
     where
         F: Fn(&SpriteFrame) -> R,


### PR DESCRIPTION
Per title. Makes it a bit clearer than `get_frame`, and reduces the requirements when rendering to reads.