### PR TITLE
Fix CI freezing

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,29 @@
+name: Audit
+
+on: [push]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Rust
+        uses: hecrj/setup-rust-action@v1
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin/cargo-audit
+          key: cargo-audit
+      - name: Install cargo-audit
+        run: cargo -v install cargo-audit
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.branch }}
+      - name: Audit
+        # RUSTSEC-2021-0119: indirect dependency, nix https://github.com/nix-rust/nix/issues/1541
+        run: |
+          cargo audit -D warnings --ignore RUSTSEC-2021-0119

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,12 +11,10 @@ jobs:
       - name: Install x11 dependencies for Kludgine
         run: |
           sudo apt-get update -y -qq
-          sudo add-apt-repository ppa:kisak/kisak-mesa -y
-          sudo apt-get install -yqq \
-            libxcb-render-util0-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev \
-            mesa-vulkan-drivers
+          sudo add-apt-repository ppa:oibaf/graphics-drivers -y
+          sudo apt-get update
+          sudo apt-get install -y \
+            libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
       - name: Run code coverage
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,32 @@
+name: Docs
+
+on: [push]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install x11 dependencies for Kludgine
+        run: |
+          sudo apt-get update -y -qq
+          sudo add-apt-repository ppa:oibaf/graphics-drivers -y
+          sudo apt-get update
+          sudo apt-get install -y \
+            libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+            
+      - name: Generate Docs
+        run: |
+          cargo doc --no-deps --all-features
+
+      - name: Deploy Docs
+        uses: JamesIves/github-pages-deploy-action@releases/v4
+        with:
+          branch: gh-pages
+          folder: target/doc/
+          git-config-name: kl-botsu
+          git-config-email: botsu@khonsulabs.com
+          target-folder: /main/
+          clean: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,32 +3,6 @@ name: Tests
 on: [push]
 
 jobs:
-  audit:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Install Rust
-        uses: hecrj/setup-rust-action@v1
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            ~/.cargo/bin/cargo-audit
-          key: cargo-audit
-      - name: Install cargo-audit
-        run: cargo -v install cargo-audit
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ matrix.branch }}
-      - name: Audit
-        # RUSTSEC-2021-0090: indirect dependency, ash https://github.com/MaikKlein/ash/issues/354
-        run: |
-          cargo audit -D warnings --ignore RUSTSEC-2021-0090
-          
-
   test:
     runs-on: ubuntu-latest
     steps:
@@ -51,33 +25,3 @@ jobs:
       - name: Run tokio unit tests
         run: |
           cargo test --no-default-features --features="tokio-rt"
-
-  docs:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install x11 dependencies for Kludgine
-        run: |
-          sudo apt-get update -y -qq
-          sudo add-apt-repository ppa:kisak/kisak-mesa -y
-          sudo apt-get install -yqq \
-            libxcb-render-util0-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev \
-            mesa-vulkan-drivers
-            
-      - name: Generate Docs
-        run: |
-          cargo doc --no-deps --all-features
-
-      - name: Deploy Docs
-        uses: JamesIves/github-pages-deploy-action@releases/v4
-        with:
-          branch: gh-pages
-          folder: target/doc/
-          git-config-name: kl-botsu
-          git-config-email: botsu@khonsulabs.com
-          target-folder: /main/
-          clean: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,12 +37,10 @@ jobs:
       - name: Install x11 dependencies for Kludgine
         run: |
           sudo apt-get update -y -qq
-          sudo add-apt-repository ppa:kisak/kisak-mesa -y
-          sudo apt-get install -yqq \
-            libxcb-render-util0-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev \
-            mesa-vulkan-drivers
+          sudo add-apt-repository ppa:oibaf/graphics-drivers -y
+          sudo apt-get update
+          sudo apt-get install -y \
+            libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
       - name: Run clippy
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v0.1.0-dev.5
 
-### Added
+### Changed
 
 - Updated dependencies for compatability with wgpu 0.11.1.
 - Implemented Sprite alpha rendering. The APIs already existed, but the alpha value was being ignored.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,3 +55,4 @@ tracing-futures = { version = "0.2" }
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
 image = { version = ">=0.23.12", default-features = false, features = ["png"] }
+tracing-subscriber = "0.3"

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,3 +1,4 @@
+use easygpu::wgpu::BufferAsyncError;
 use easygpu_lyon::lyon_tessellation::TessellationError;
 
 /// All errors that `kludgine-core` can return.
@@ -18,4 +19,7 @@ pub enum Error {
     /// The sprite's current tag has no frames.
     #[error("no frames could be found for the current tag")]
     InvalidSpriteTag,
+    /// An error occurred during offscreen rendering.
+    #[error("error acquiring offscreen buffer: {0}")]
+    Offscreen(#[from] BufferAsyncError),
 }

--- a/core/src/tests.rs
+++ b/core/src/tests.rs
@@ -1,5 +1,6 @@
 use easygpu::wgpu;
 use image::{GenericImageView, Rgba};
+use tracing::Level;
 use winit::window::Theme;
 
 use crate::{frame_renderer::FrameRenderer, prelude::*, sprite::Srgb};
@@ -7,6 +8,9 @@ use crate::{frame_renderer::FrameRenderer, prelude::*, sprite::Srgb};
 #[tokio::test]
 #[allow(clippy::semicolon_if_nothing_returned)] // false positive from tokio::test
 async fn offscreen_render_test() {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::TRACE)
+        .init();
     let (scene_sender, scene_receiver) = flume::unbounded();
 
     let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);


### PR DESCRIPTION
In my haste to try to work on Gooey last night, I published a kludgine update without waiting for CI to finish. After both Kludgine and Gooey's CI timed out, I launched the investigation.

In the end there is a "fix" -- I think the old code (while amateurish with its usage of boxing futures and fusing, which are unnecessary here I now know) was technically more correct than what is happening here. I put in an issue for the wgpu developers to see: gfx-rs/wgpu#2266.

This also overhauls the CI workflows so that they're split. The dependencies have been switched to those that are in the wgpu repository's workflows.