### PR TITLE
Convert the measured line width into Px conservatively

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -535,7 +535,7 @@ pub(crate) fn map_each_glyph(
                 glyph,
                 (run.line_top / metrics.line_height).round().cast::<usize>(),
                 relative_to.y,
-                Px::from(run.line_w),
+                Px::from(run.line_w.ceil()),
                 kludgine,
             );
         }


### PR DESCRIPTION
This ensures the text layout algorithm is able to fit the same line-breaks\nin a new bounding box generated from the measured length.

This is used in gooey's Label implementation.

**Note**: I think it'd be a good idea to remove the trait-based `from_float` conversion for `Px`, as the rounding mode will often be important to customize like in this case. The `From::from` instance makes it too easy to forget (Maybe some explicit `Px::round_{up,down}` methods?)